### PR TITLE
Restructure settings menu and add shot limit off option

### DIFF
--- a/code/code.ino
+++ b/code/code.ino
@@ -46,9 +46,11 @@ float recoilThreshold = 1.5f;
 int screenRotationSetting = 3;
 bool playBootAnimation = false;
 bool enableAutoSleep = true;
-bool showTotalTime = true;
+
 int minFirstShotTimeMs = 100;
 int postBeepDelayMs = 200;
+int startDelayMinMs = 2000;
+int startDelayMaxMs = 5000;
 
 BluetoothA2DPSource a2dp_source;
 String currentBluetoothDeviceName = "LEXON MINO L";
@@ -69,6 +71,8 @@ volatile unsigned long current_bt_beep_actual_end_time = 0;
 // --- Timer State Variables ---
 volatile bool is_listening_active = false;      // Definition
 volatile unsigned long beep_audio_end_time = 0; // Definition
+unsigned long liveFireDelayEndTime = 0;
+bool liveFireWaitingForDelay = false;
 
 
 ESP32BluetoothScanner btScanner;
@@ -316,6 +320,7 @@ void loop() {
             else if (currentState != SETTINGS_MENU_MAIN && currentState != SETTINGS_MENU_GENERAL &&
                      currentState != SETTINGS_MENU_BEEP && currentState != SETTINGS_MENU_BLUETOOTH &&
                      currentState != SETTINGS_MENU_DRYFIRE && currentState != SETTINGS_MENU_NOISY &&
+                     currentState != SETTINGS_MENU_DEVICE &&
                      currentState != BLUETOOTH_SCANNING && 
                      currentState != DEVICE_STATUS && currentState != LIST_FILES && 
                      currentState != EDIT_SETTING && currentState != CALIBRATE_THRESHOLD && 
@@ -443,7 +448,8 @@ void loop() {
         case SETTINGS_MENU_BEEP:
         case SETTINGS_MENU_DRYFIRE:
         case SETTINGS_MENU_NOISY:
-        case SETTINGS_MENU_BLUETOOTH: handleSettingsInput(); break;
+        case SETTINGS_MENU_BLUETOOTH:
+        case SETTINGS_MENU_DEVICE:    handleSettingsInput(); break;
         case BLUETOOTH_SCANNING:      handleBluetoothScanning(); break;
         case EDIT_SETTING:            handleEditSettingInput(); break;
         case DEVICE_STATUS:           handleDeviceStatusInput(); break;

--- a/code/config.cpp
+++ b/code/config.cpp
@@ -16,6 +16,8 @@ const char* KEY_BT_DEVICE_NAME = "btDevName";
 const char* KEY_BT_AUTO_RECONNECT = "btAutoRec";
 const char* KEY_BT_VOLUME = "btVolume";
 const char* KEY_BT_AUDIO_OFFSET = "btAudioOffset"; // New NVS Key Definition
-const char* KEY_SHOW_TOTAL_TIME = "showTotTime";
+
 const char* KEY_MIN_FIRST_SHOT = "minFirstShot";
 const char* KEY_POST_BEEP_DELAY = "postBeepDly";
+const char* KEY_START_DELAY_MIN = "startDlyMin";
+const char* KEY_START_DELAY_MAX = "startDlyMax";

--- a/code/config.h
+++ b/code/config.h
@@ -11,7 +11,7 @@ const unsigned long BEEP_NOTE_DURATION_MS = 150;
 const unsigned long BEEP_NOTE_DELAY_MS = 50;
 const unsigned long BATTERY_CHECK_INTERVAL_MS = 60000;
 const float BATTERY_LOW_PERCENTAGE = 0.78f;
-const int MAX_SHOTS_LIMIT = 20;
+const int MAX_SHOTS_LIMIT = 99;
 const int MENU_ITEM_HEIGHT_LANDSCAPE = 25;
 const int MENU_ITEM_HEIGHT_PORTRAIT = 18;
 const int MENU_ITEMS_PER_SCREEN_LANDSCAPE = 3;
@@ -26,6 +26,9 @@ const unsigned long DRY_FIRE_RANDOM_DELAY_MAX_MS = 5000;
 const int MAX_PAR_BEEPS = 10;
 const unsigned long RECOIL_DETECTION_WINDOW_MS = 100;
 const unsigned long DEFAULT_MIN_FIRST_SHOT_TIME_MS = 100; // Default min time after start for first shot
+const int DEFAULT_START_DELAY_MIN_MS = 2000;
+const int DEFAULT_START_DELAY_MAX_MS = 5000;
+const int MAX_START_DELAY_MS = 10000;
 const unsigned long AUTO_SLEEP_TIMEOUT_MS = 1 * 60 * 1000;
 const unsigned long SLEEP_MESSAGE_DELAY_MS = 1500;
 // #define C3_FREQUENCY 130.81f // No longer used for keep-alive
@@ -56,9 +59,11 @@ extern const char* KEY_BT_DEVICE_NAME;
 extern const char* KEY_BT_AUTO_RECONNECT;
 extern const char* KEY_BT_VOLUME;
 extern const char* KEY_BT_AUDIO_OFFSET; 
-extern const char* KEY_SHOW_TOTAL_TIME;
+
 extern const char* KEY_MIN_FIRST_SHOT;
 extern const char* KEY_POST_BEEP_DELAY;
+extern const char* KEY_START_DELAY_MIN;
+extern const char* KEY_START_DELAY_MAX;
 
 // --- Timer States ---
 enum TimerState {
@@ -80,6 +85,7 @@ enum TimerState {
     SETTINGS_MENU_DRYFIRE,
     SETTINGS_MENU_NOISY,
     SETTINGS_MENU_BLUETOOTH,
+    SETTINGS_MENU_DEVICE,
     BLUETOOTH_SCANNING,
     DEVICE_STATUS,
     LIST_FILES,
@@ -111,10 +117,12 @@ enum EditableSetting {
     EDIT_BT_AUTO_RECONNECT,
     EDIT_BT_VOLUME,
     EDIT_BT_AUDIO_OFFSET,
-    EDIT_SHOW_TOTAL_TIME,
+
     EDIT_MIN_FIRST_SHOT,
     EDIT_POST_BEEP_DELAY,
-    EDIT_TONE_SWEEP 
+    EDIT_TONE_SWEEP,
+    EDIT_START_DELAY_MIN,
+    EDIT_START_DELAY_MAX
 };
 
 // --- Struct for Buzzer Task Queue ---

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -99,7 +99,8 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
                               strcmp(items[i], "Power Off Now") == 0 ||
                               strcmp(items[i], "Beep Settings") == 0 ||
                               strcmp(items[i], "Bluetooth Settings") == 0 ||
-                              strcmp(items[i], "Tone Sweep") == 0);
+                              strcmp(items[i], "Tone Sweep") == 0 ||
+                              strcmp(items[i], "Save & Exit") == 0);
 
         bool isParTimeSetting = (settingsMenuLevel == 2 && strncmp(items[i], "Par Time", 8) == 0);
         bool isBluetoothConnectItem = (settingsMenuLevel == 5 && strcmp(items[i], "Connect") == 0 );
@@ -108,7 +109,7 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
 
         if (settingsMenuLevel > 0 && !isNavOrAction && !isParTimeSetting && !isBluetoothConnectItem && !isBluetoothScanItem && !isBluetoothDisconnectItem) {
             itemText += ": ";
-            if (strcmp(items[i], "Max Shots") == 0) itemText += currentMaxShots;
+            if (strcmp(items[i], "Max Shots") == 0) { if (currentMaxShots == 0) itemText += "Off"; else itemText += currentMaxShots; }
             else if (strcmp(items[i], "Beep Duration") == 0) itemText += currentBeepDuration;
             else if (strcmp(items[i], "Beep Tone") == 0) itemText += currentBeepToneHz;
             else if (strcmp(items[i], "Shot Threshold") == 0) itemText += shotThresholdRms;
@@ -117,9 +118,11 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
             else if (strcmp(items[i], "Screen Rotation") == 0) itemText += screenRotationSetting;
             else if (strcmp(items[i], "Boot Animation") == 0) itemText += (playBootAnimation ? "On" : "Off");
             else if (strcmp(items[i], "Auto Sleep") == 0) itemText += (enableAutoSleep ? "On" : "Off");
-            else if (strcmp(items[i], "Show Total Time") == 0) itemText += (showTotalTime ? "On" : "Off");
+
             else if (strcmp(items[i], "Min 1st Shot") == 0) { itemText += minFirstShotTimeMs; itemText += "ms"; }
             else if (strcmp(items[i], "Post Beep Delay") == 0) { itemText += postBeepDelayMs; itemText += "ms"; }
+            else if (strcmp(items[i], "Start Delay Min") == 0) { itemText += startDelayMinMs; itemText += "ms"; }
+            else if (strcmp(items[i], "Start Delay Max") == 0) { itemText += startDelayMaxMs; itemText += "ms"; }
             else if (settingsMenuLevel == 5 && strcmp(items[i], "Auto Reconnect") == 0) {
                 itemText += (currentBluetoothAutoReconnect ? "On" : "Off");
             }
@@ -196,7 +199,8 @@ void displayTimingScreen(float elapsedTime, int count, float lastSplit) {
         StickCP2.Lcd.setTextSize(text_size);
         StickCP2.Lcd.fillRect(10, shots_y, StickCP2.Lcd.width() - 20, line_h, BLACK);
         StickCP2.Lcd.setCursor(10, shots_y);
-        StickCP2.Lcd.printf("Shots: %d/%d", count, currentMaxShots);
+        if (currentMaxShots == 0) StickCP2.Lcd.printf("Shots: %d", count);
+        else StickCP2.Lcd.printf("Shots: %d/%d", count, currentMaxShots);
         prevCount = count;
     }
 
@@ -233,17 +237,15 @@ void displayStoppedScreen() {
 
     StickCP2.Lcd.setTextSize(text_size);
 
-    if (showTotalTime && shotCount > 0) {
-        // Show total elapsed time (buzzer to last shot) with shot count
+    if (shotCount > 0) {
         float totalTime = (shotTimestamps[shotCount - 1] - startTime) / 1000.0f;
         StickCP2.Lcd.setCursor(10, y_pos);
         StickCP2.Lcd.printf("Total: %.2fs (%d)", totalTime, shotCount);
-        y_pos += line_h;
     } else {
         StickCP2.Lcd.setCursor(10, y_pos);
         StickCP2.Lcd.printf("Total Shots: %d", shotCount);
-        y_pos += line_h;
     }
+    y_pos += line_h;
 
     StickCP2.Lcd.setCursor(10, y_pos);
     if (shotCount > 0) { StickCP2.Lcd.printf("First: %.2fs", splitTimes[0]); }
@@ -345,7 +347,7 @@ void displayEditScreen() {
         StickCP2.Lcd.setTextDatum(BC_DATUM);
         StickCP2.Lcd.setTextFont(0);
         StickCP2.Lcd.setTextSize(1);
-        if (settingBeingEdited == EDIT_BOOT_ANIM || settingBeingEdited == EDIT_AUTO_SLEEP || settingBeingEdited == EDIT_BT_AUTO_RECONNECT || settingBeingEdited == EDIT_SHOW_TOTAL_TIME) {
+        if (settingBeingEdited == EDIT_BOOT_ANIM || settingBeingEdited == EDIT_AUTO_SLEEP || settingBeingEdited == EDIT_BT_AUTO_RECONNECT) {
             StickCP2.Lcd.drawString(getUpButtonLabel() + " or " + getDownButtonLabel() + " = Toggle", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 25);
         } else {
             StickCP2.Lcd.drawString(getUpButtonLabel() + "=Up / " + getDownButtonLabel() + "=Down", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 25);
@@ -357,6 +359,14 @@ void displayEditScreen() {
 
     switch(settingBeingEdited) {
         case EDIT_MAX_SHOTS:
+             if (editingIntValue == 0) {
+                 StickCP2.Lcd.setTextFont(4); StickCP2.Lcd.setTextSize(1);
+                 StickCP2.Lcd.drawString("Off", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
+             } else {
+                 StickCP2.Lcd.setTextFont(7); StickCP2.Lcd.setTextSize(1);
+                 StickCP2.Lcd.drawNumber(editingIntValue, StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
+             }
+             break;
         case EDIT_BEEP_TONE:
         case EDIT_SHOT_THRESHOLD:
         case EDIT_PAR_BEEP_COUNT:
@@ -365,10 +375,13 @@ void displayEditScreen() {
         case EDIT_BT_AUDIO_OFFSET: 
         case EDIT_MIN_FIRST_SHOT:
         case EDIT_POST_BEEP_DELAY:
+        case EDIT_START_DELAY_MIN:
+        case EDIT_START_DELAY_MAX:
         case EDIT_TONE_SWEEP:
              StickCP2.Lcd.setTextFont(7); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawNumber(editingIntValue, StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
-             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT || settingBeingEdited == EDIT_POST_BEEP_DELAY) { 
+             if (settingBeingEdited == EDIT_BT_AUDIO_OFFSET || settingBeingEdited == EDIT_MIN_FIRST_SHOT || settingBeingEdited == EDIT_POST_BEEP_DELAY ||
+                 settingBeingEdited == EDIT_START_DELAY_MIN || settingBeingEdited == EDIT_START_DELAY_MAX) {
                 StickCP2.Lcd.setTextFont(0); StickCP2.Lcd.setTextSize(1); 
                 StickCP2.Lcd.drawString("ms", StickCP2.Lcd.width() / 2 + StickCP2.Lcd.textWidth(String(editingIntValue))/2 + 15, StickCP2.Lcd.height() / 2);
              }
@@ -389,7 +402,6 @@ void displayEditScreen() {
         case EDIT_BOOT_ANIM:
         case EDIT_AUTO_SLEEP:
         case EDIT_BT_AUTO_RECONNECT:
-        case EDIT_SHOW_TOTAL_TIME:
              StickCP2.Lcd.setTextFont(4); StickCP2.Lcd.setTextSize(1);
              StickCP2.Lcd.drawString(editingBoolValue ? "On" : "Off", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
              break;

--- a/code/globals.h
+++ b/code/globals.h
@@ -33,9 +33,11 @@ extern float recoilThreshold;
 extern int screenRotationSetting;
 extern bool playBootAnimation;
 extern bool enableAutoSleep;
-extern bool showTotalTime;
+
 extern int minFirstShotTimeMs;
 extern int postBeepDelayMs;
+extern int startDelayMinMs;
+extern int startDelayMaxMs;
 
 // --- Bluetooth Variables ---
 extern BluetoothA2DPSource a2dp_source;
@@ -57,6 +59,8 @@ extern volatile unsigned long current_bt_beep_actual_end_time;
 // --- Timer State Variables ---
 extern volatile bool is_listening_active;      // Flag to enable/disable mic reading after start beep
 extern volatile unsigned long beep_audio_end_time; // Calculated time when start beep audio should be finished
+extern unsigned long liveFireDelayEndTime;
+extern bool liveFireWaitingForDelay;
 
 
 // Bluetooth Scanner Variables

--- a/code/input_handler.cpp
+++ b/code/input_handler.cpp
@@ -59,10 +59,11 @@ void handleSettingsInput() {
     int rotation = StickCP2.Lcd.getRotation();
     int itemsPerScreen = (rotation % 2 == 0) ? MENU_ITEMS_PER_SCREEN_PORTRAIT : MENU_ITEMS_PER_SCREEN_LANDSCAPE;
 
-    static const char* mainItems[] = {"General", "Bluetooth", "Dry Fire", "Noisy Range", "Device Status", "List Files", "Power Off Now", "Save & Exit"};
-    static const char* generalItems[] = {"Max Shots", "Beep Settings", "Shot Threshold", "Min 1st Shot", "Post Beep Delay", "Screen Rotation", "Boot Animation", "Auto Sleep", "Show Total Time", "Calibrate Thresh.", "Back"};
-    static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Tone Sweep", "Back"};
+    static const char* mainItems[] = {"Live Fire", "Dry Fire", "Noisy Range", "Beep Settings", "Bluetooth", "Device", "Power Off Now", "Save & Exit"};
+    static const char* liveFireItems[] = {"Max Shots", "Shot Threshold", "Min 1st Shot", "Start Delay Min", "Start Delay Max", "Calibrate Thresh.", "Back"};
+    static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Post Beep Delay", "Tone Sweep", "Back"};
     static const char* noisyItems[] = {"Recoil Threshold", "Calibrate Recoil", "Back"};
+    static const char* deviceItems[] = {"Screen Rotation", "Boot Animation", "Auto Sleep", "Device Status", "List Files", "Back"};
 
     const int maxDryFireItems = 1 + MAX_PAR_BEEPS + 1;
     static const char* dryFireItemsBuffer[maxDryFireItems];
@@ -78,9 +79,9 @@ void handleSettingsInput() {
             title = "Settings";
             break;
         case 1:
-            items = generalItems;
-            itemCount = sizeof(generalItems) / sizeof(generalItems[0]);
-            title = "General Settings";
+            items = liveFireItems;
+            itemCount = sizeof(liveFireItems) / sizeof(liveFireItems[0]);
+            title = "Live Fire Settings";
             break;
         case 2:
             title = "Dry Fire Settings";
@@ -103,7 +104,12 @@ void handleSettingsInput() {
              itemCount = sizeof(beepItems) / sizeof(beepItems[0]);
              title = "Beep Settings";
              break;
-        case 5: 
+        case 6:
+            items = deviceItems;
+            itemCount = sizeof(deviceItems) / sizeof(deviceItems[0]);
+            title = "Device Settings";
+            break;
+        case 5:
             title = "Bluetooth Settings";
             bluetoothItems[0] = "Connect"; 
             bluetoothItems[1] = "Disconnect";
@@ -146,14 +152,18 @@ void handleSettingsInput() {
          if (settingsMenuLevel == 0) {
              setState(MODE_SELECTION); currentMenuSelection = (int)currentMode; menuScrollOffset = 0;
              StickCP2.Lcd.fillScreen(BLACK);
-         } else if (settingsMenuLevel == 1 || settingsMenuLevel == 2 || settingsMenuLevel == 3 || settingsMenuLevel == 5) {
+         } else {
              int oldMenuLevel = settingsMenuLevel;
              settingsMenuLevel = 0;
-             currentMenuSelection = (oldMenuLevel == 5 ? 1 : (oldMenuLevel == 2 ? 2 : (oldMenuLevel == 3 ? 3 : 0) ) ); 
-             menuScrollOffset = 0;
-             redrawMenu = true;
-         } else if (settingsMenuLevel == 4) {
-             settingsMenuLevel = 1; currentMenuSelection = 1; 
+             switch (oldMenuLevel) {
+                 case 1: currentMenuSelection = 0; break; // Live Fire
+                 case 2: currentMenuSelection = 1; break; // Dry Fire
+                 case 3: currentMenuSelection = 2; break; // Noisy Range
+                 case 4: currentMenuSelection = 3; break; // Beep Settings
+                 case 5: currentMenuSelection = 4; break; // Bluetooth
+                 case 6: currentMenuSelection = 5; break; // Device
+                 default: currentMenuSelection = 0; break;
+             }
              menuScrollOffset = 0; redrawMenu = true;
          }
          return;
@@ -163,16 +173,12 @@ void handleSettingsInput() {
         bool needsActionRedraw = true;
 
         if (settingsMenuLevel == 0) {
-            if (strcmp(items[currentMenuSelection], "General") == 0) settingsMenuLevel = 1;
-            else if (strcmp(items[currentMenuSelection], "Bluetooth") == 0) settingsMenuLevel = 5;
+            if (strcmp(items[currentMenuSelection], "Live Fire") == 0) settingsMenuLevel = 1;
             else if (strcmp(items[currentMenuSelection], "Dry Fire") == 0) settingsMenuLevel = 2;
             else if (strcmp(items[currentMenuSelection], "Noisy Range") == 0) settingsMenuLevel = 3;
-            else if (strcmp(items[currentMenuSelection], "Device Status") == 0) {
-                setState(DEVICE_STATUS); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            }
-            else if (strcmp(items[currentMenuSelection], "List Files") == 0) {
-                setState(LIST_FILES); fileListScrollOffset = 0; needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            }
+            else if (strcmp(items[currentMenuSelection], "Beep Settings") == 0) settingsMenuLevel = 4;
+            else if (strcmp(items[currentMenuSelection], "Bluetooth") == 0) settingsMenuLevel = 5;
+            else if (strcmp(items[currentMenuSelection], "Device") == 0) settingsMenuLevel = 6;
             else if (strcmp(items[currentMenuSelection], "Power Off Now") == 0) {
                 StickCP2.Lcd.fillScreen(BLACK);
                 StickCP2.Lcd.setTextDatum(MC_DATUM);
@@ -187,31 +193,23 @@ void handleSettingsInput() {
             }
             currentMenuSelection = 0; menuScrollOffset = 0;
         }
-        else if (settingsMenuLevel == 1) { 
+        else if (settingsMenuLevel == 1) {
             editingSettingName = items[currentMenuSelection];
             stateBeforeEdit = SETTINGS_MENU_GENERAL;
             if (strcmp(editingSettingName, "Max Shots") == 0) {
                 settingBeingEdited = EDIT_MAX_SHOTS; editingIntValue = currentMaxShots; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Beep Settings") == 0) {
-                settingsMenuLevel = 4; currentMenuSelection = 0; menuScrollOffset = 0; 
             } else if (strcmp(editingSettingName, "Shot Threshold") == 0) {
                 settingBeingEdited = EDIT_SHOT_THRESHOLD; editingIntValue = shotThresholdRms; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Min 1st Shot") == 0) {
                 settingBeingEdited = EDIT_MIN_FIRST_SHOT; editingIntValue = minFirstShotTimeMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Post Beep Delay") == 0) {
-                settingBeingEdited = EDIT_POST_BEEP_DELAY; editingIntValue = postBeepDelayMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Screen Rotation") == 0) {
-                settingBeingEdited = EDIT_ROTATION; editingIntValue = screenRotationSetting; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Boot Animation") == 0) {
-                settingBeingEdited = EDIT_BOOT_ANIM; editingBoolValue = playBootAnimation; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Auto Sleep") == 0) {
-                settingBeingEdited = EDIT_AUTO_SLEEP; editingBoolValue = enableAutoSleep; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
-            } else if (strcmp(editingSettingName, "Show Total Time") == 0) {
-                settingBeingEdited = EDIT_SHOW_TOTAL_TIME; editingBoolValue = showTotalTime; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Start Delay Min") == 0) {
+                settingBeingEdited = EDIT_START_DELAY_MIN; editingIntValue = startDelayMinMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Start Delay Max") == 0) {
+                settingBeingEdited = EDIT_START_DELAY_MAX; editingIntValue = startDelayMaxMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Calibrate Thresh.") == 0) {
                 setState(CALIBRATE_THRESHOLD); peakRMSOverall = 0; micPeakRMS.resetPeak(); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Back") == 0) {
-                settingsMenuLevel = 0; currentMenuSelection = 0; menuScrollOffset = 0; 
+                settingsMenuLevel = 0; currentMenuSelection = 0; menuScrollOffset = 0;
             }
         }
         else if (settingsMenuLevel == 2) { 
@@ -235,10 +233,10 @@ void handleSettingsInput() {
                     StickCP2.Lcd.fillScreen(BLACK);
                 }
             } else if (strcmp(items[currentMenuSelection], "Back") == 0) {
-                settingsMenuLevel = 0; currentMenuSelection = 2; menuScrollOffset = 0; 
+                settingsMenuLevel = 0; currentMenuSelection = 1; menuScrollOffset = 0;
             }
         }
-        else if (settingsMenuLevel == 3) { 
+        else if (settingsMenuLevel == 3) {
             editingSettingName = items[currentMenuSelection];
             stateBeforeEdit = SETTINGS_MENU_NOISY;
             if (strcmp(editingSettingName, "Recoil Threshold") == 0) {
@@ -246,20 +244,22 @@ void handleSettingsInput() {
             } else if (strcmp(editingSettingName, "Calibrate Recoil") == 0) {
                 setState(CALIBRATE_RECOIL); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK); peakRecoilValue = 0;
             } else if (strcmp(editingSettingName, "Back") == 0) {
-                settingsMenuLevel = 0; currentMenuSelection = 3; menuScrollOffset = 0; 
+                settingsMenuLevel = 0; currentMenuSelection = 2; menuScrollOffset = 0;
             }
         }
-        else if (settingsMenuLevel == 4) { 
+        else if (settingsMenuLevel == 4) {
             editingSettingName = items[currentMenuSelection];
             stateBeforeEdit = SETTINGS_MENU_BEEP;
-             if (strcmp(editingSettingName, "Beep Duration") == 0) {
+            if (strcmp(editingSettingName, "Beep Duration") == 0) {
                 settingBeingEdited = EDIT_BEEP_DURATION; editingULongValue = currentBeepDuration; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Beep Tone") == 0) {
                 settingBeingEdited = EDIT_BEEP_TONE; editingIntValue = currentBeepToneHz; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Post Beep Delay") == 0) {
+                settingBeingEdited = EDIT_POST_BEEP_DELAY; editingIntValue = postBeepDelayMs; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Tone Sweep") == 0) {
                 settingBeingEdited = EDIT_TONE_SWEEP; editingIntValue = 2000; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "Back") == 0) {
-                settingsMenuLevel = 1; currentMenuSelection = 1; 
+                settingsMenuLevel = 0; currentMenuSelection = 3;
                 menuScrollOffset = 0;
             }
         }
@@ -339,7 +339,24 @@ void handleSettingsInput() {
                 // --- End Scan Setup ---
             }
             else if (strcmp(items[currentMenuSelection], "Back") == 0) {
-                settingsMenuLevel = 0; currentMenuSelection = 1; menuScrollOffset = 0; 
+                settingsMenuLevel = 0; currentMenuSelection = 4; menuScrollOffset = 0;
+            }
+        }
+        else if (settingsMenuLevel == 6) {
+            editingSettingName = items[currentMenuSelection];
+            stateBeforeEdit = SETTINGS_MENU_DEVICE;
+            if (strcmp(editingSettingName, "Screen Rotation") == 0) {
+                settingBeingEdited = EDIT_ROTATION; editingIntValue = screenRotationSetting; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Boot Animation") == 0) {
+                settingBeingEdited = EDIT_BOOT_ANIM; editingBoolValue = playBootAnimation; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Auto Sleep") == 0) {
+                settingBeingEdited = EDIT_AUTO_SLEEP; editingBoolValue = enableAutoSleep; setState(EDIT_SETTING); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Device Status") == 0) {
+                setState(DEVICE_STATUS); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "List Files") == 0) {
+                setState(LIST_FILES); fileListScrollOffset = 0; needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Back") == 0) {
+                settingsMenuLevel = 0; currentMenuSelection = 5; menuScrollOffset = 0;
             }
         }
         if (needsActionRedraw) redrawMenu = true;
@@ -358,7 +375,13 @@ void handleEditSettingInput() {
         int increment = upPressed ? 1 : -1;
 
         switch(settingBeingEdited) {
-            case EDIT_MAX_SHOTS: editingIntValue = min(max(editingIntValue + increment, 1), MAX_SHOTS_LIMIT); break;
+            case EDIT_MAX_SHOTS: {
+                int newVal = editingIntValue + increment;
+                if (newVal > MAX_SHOTS_LIMIT) newVal = 0;
+                else if (newVal < 0) newVal = MAX_SHOTS_LIMIT;
+                editingIntValue = newVal;
+                break;
+            }
             case EDIT_BEEP_DURATION: editingULongValue = min(max(editingULongValue + (unsigned long)(increment * 50), 50UL), 2000UL); break;
             case EDIT_BEEP_TONE: editingIntValue = min(max(editingIntValue + (increment * 100), 500), 8000); break;
             case EDIT_SHOT_THRESHOLD: editingIntValue = min(max(editingIntValue + (increment * 500), 100), 32000); break;
@@ -370,7 +393,6 @@ void handleEditSettingInput() {
             case EDIT_ROTATION: editingIntValue = (editingIntValue + increment + 4) % 4; break;
             case EDIT_BOOT_ANIM: editingBoolValue = !editingBoolValue; break;
             case EDIT_AUTO_SLEEP: editingBoolValue = !editingBoolValue; break;
-            case EDIT_SHOW_TOTAL_TIME: editingBoolValue = !editingBoolValue; break;
             case EDIT_BT_AUTO_RECONNECT: editingBoolValue = !editingBoolValue; break;
             case EDIT_BT_VOLUME:
                 editingIntValue = min(max(editingIntValue + (increment * 5), 0), 127);
@@ -387,6 +409,12 @@ void handleEditSettingInput() {
                 editingIntValue = min(max(editingIntValue + (increment * 50), 2000), 4000);
                 playFeedbackTone(editingIntValue, 100);
                 break;
+            case EDIT_START_DELAY_MIN:
+                editingIntValue = min(max(editingIntValue + (increment * 250), 0), min(startDelayMaxMs, MAX_START_DELAY_MS));
+                break;
+            case EDIT_START_DELAY_MAX:
+                editingIntValue = min(max(editingIntValue + (increment * 250), startDelayMinMs), MAX_START_DELAY_MS);
+                break;
             default: valueChanged = false; break;
         }
         if (settingBeingEdited == EDIT_ROTATION) {
@@ -396,7 +424,6 @@ void handleEditSettingInput() {
         if (valueChanged && 
             settingBeingEdited != EDIT_BOOT_ANIM && 
             settingBeingEdited != EDIT_AUTO_SLEEP && 
-            settingBeingEdited != EDIT_SHOW_TOTAL_TIME &&
             settingBeingEdited != EDIT_BT_AUTO_RECONNECT &&
             settingBeingEdited != EDIT_BT_AUDIO_OFFSET &&
             settingBeingEdited != EDIT_TONE_SWEEP) { 
@@ -434,7 +461,6 @@ void handleEditSettingInput() {
             case EDIT_ROTATION: screenRotationSetting = editingIntValue; break;
             case EDIT_BOOT_ANIM: playBootAnimation = editingBoolValue; break;
             case EDIT_AUTO_SLEEP: enableAutoSleep = editingBoolValue; break;
-            case EDIT_SHOW_TOTAL_TIME: showTotalTime = editingBoolValue; break;
             case EDIT_BT_AUTO_RECONNECT:
                 currentBluetoothAutoReconnect = editingBoolValue;
                 break;
@@ -442,9 +468,11 @@ void handleEditSettingInput() {
                 currentBluetoothVolume = editingIntValue;
                 a2dp_source.set_volume(currentBluetoothVolume);
                 break;
-            case EDIT_BT_AUDIO_OFFSET: 
+            case EDIT_BT_AUDIO_OFFSET:
                 currentBluetoothAudioOffsetMs = editingIntValue;
                 break;
+            case EDIT_START_DELAY_MIN: startDelayMinMs = editingIntValue; break;
+            case EDIT_START_DELAY_MAX: startDelayMaxMs = editingIntValue; break;
             default: break;
         }
         setState(stateBeforeEdit);
@@ -467,11 +495,10 @@ void handleDeviceStatusInput() {
         redrawMenu = false;
     }
     if (StickCP2.BtnA.pressedFor(LONG_PRESS_DURATION_MS)) {
-        setState(SETTINGS_MENU_MAIN);
-        currentMenuSelection = 4; 
-        int rotation = StickCP2.Lcd.getRotation();
-        int itemsPerScreen = (rotation % 2 == 0) ? MENU_ITEMS_PER_SCREEN_PORTRAIT : MENU_ITEMS_PER_SCREEN_LANDSCAPE;
-        menuScrollOffset = max(0, currentMenuSelection - itemsPerScreen + 1);
+        setState(SETTINGS_MENU_DEVICE);
+        settingsMenuLevel = 6;
+        currentMenuSelection = 3;
+        menuScrollOffset = 0;
         StickCP2.Lcd.fillScreen(BLACK);
     }
 }
@@ -520,9 +547,10 @@ void handleListFilesInput() {
     }
 
      if (StickCP2.BtnA.pressedFor(LONG_PRESS_DURATION_MS)) {
-         setState(SETTINGS_MENU_MAIN);
-         currentMenuSelection = 5; 
-         menuScrollOffset = max(0, currentMenuSelection - itemsPerScreen + 1);
+         setState(SETTINGS_MENU_DEVICE);
+         settingsMenuLevel = 6;
+         currentMenuSelection = 4;
+         menuScrollOffset = 0;
          StickCP2.Lcd.fillScreen(BLACK);
      }
 }
@@ -575,8 +603,9 @@ void handleCalibrationInput(TimerState calibrationType) {
 
     if (StickCP2.BtnA.pressedFor(LONG_PRESS_DURATION_MS)) {
         stateBeforeEdit = (calibrationType == CALIBRATE_THRESHOLD) ? SETTINGS_MENU_GENERAL : SETTINGS_MENU_NOISY;
+        settingsMenuLevel = (calibrationType == CALIBRATE_THRESHOLD) ? 1 : 3;
         setState(stateBeforeEdit);
-        currentMenuSelection = (calibrationType == CALIBRATE_THRESHOLD) ? 6 : 1; 
+        currentMenuSelection = (calibrationType == CALIBRATE_THRESHOLD) ? 5 : 1;
         menuScrollOffset = max(0, currentMenuSelection - itemsPerScreen + 1);
         StickCP2.Lcd.fillScreen(BLACK);
         playUnsuccessBeeps();
@@ -584,12 +613,14 @@ void handleCalibrationInput(TimerState calibrationType) {
         if (calibrationType == CALIBRATE_THRESHOLD) {
             shotThresholdRms = (int)peakRMSOverall;
             stateBeforeEdit = SETTINGS_MENU_GENERAL;
+            settingsMenuLevel = 1;
             setState(stateBeforeEdit);
-            currentMenuSelection = 6;
+            currentMenuSelection = 5;
             menuScrollOffset = max(0, currentMenuSelection - itemsPerScreen + 1);
         } else if (calibrationType == CALIBRATE_RECOIL) {
             recoilThreshold = peakRecoilValue;
             stateBeforeEdit = SETTINGS_MENU_NOISY;
+            settingsMenuLevel = 3;
             setState(stateBeforeEdit);
             currentMenuSelection = 1;
             menuScrollOffset = max(0, currentMenuSelection - itemsPerScreen + 1);

--- a/code/nvs_utils.cpp
+++ b/code/nvs_utils.cpp
@@ -7,7 +7,7 @@ void loadSettings() {
 
     currentMaxShots = preferences.getInt(KEY_MAX_SHOTS, 10);
     if (currentMaxShots > MAX_SHOTS_LIMIT) currentMaxShots = MAX_SHOTS_LIMIT;
-    else if (currentMaxShots <= 0) currentMaxShots = 1;
+    else if (currentMaxShots < 0) currentMaxShots = 0;
 
     currentBeepDuration = preferences.getULong(KEY_BEEP_DUR, 150);
     currentBeepToneHz = preferences.getInt(KEY_BEEP_HZ, 2000);
@@ -27,13 +27,21 @@ void loadSettings() {
     if (screenRotationSetting < 0 || screenRotationSetting > 3) screenRotationSetting = 3;
     playBootAnimation = preferences.getBool(KEY_BOOT_ANIM, false);
     enableAutoSleep = preferences.getBool(KEY_AUTO_SLEEP, true);
-    showTotalTime = preferences.getBool(KEY_SHOW_TOTAL_TIME, true);
+
     minFirstShotTimeMs = preferences.getInt(KEY_MIN_FIRST_SHOT, DEFAULT_MIN_FIRST_SHOT_TIME_MS);
     if (minFirstShotTimeMs < 0) minFirstShotTimeMs = 0;
     if (minFirstShotTimeMs > 500) minFirstShotTimeMs = 500;
     postBeepDelayMs = preferences.getInt(KEY_POST_BEEP_DELAY, DEFAULT_POST_BEEP_DELAY_MS);
     if (postBeepDelayMs < 50) postBeepDelayMs = 50;
     if (postBeepDelayMs > 1000) postBeepDelayMs = 1000;
+
+    startDelayMinMs = preferences.getInt(KEY_START_DELAY_MIN, DEFAULT_START_DELAY_MIN_MS);
+    if (startDelayMinMs < 0) startDelayMinMs = 0;
+    if (startDelayMinMs > MAX_START_DELAY_MS) startDelayMinMs = MAX_START_DELAY_MS;
+    startDelayMaxMs = preferences.getInt(KEY_START_DELAY_MAX, DEFAULT_START_DELAY_MAX_MS);
+    if (startDelayMaxMs < 0) startDelayMaxMs = 0;
+    if (startDelayMaxMs > MAX_START_DELAY_MS) startDelayMaxMs = MAX_START_DELAY_MS;
+    if (startDelayMaxMs < startDelayMinMs) startDelayMaxMs = startDelayMinMs;
 
     currentBluetoothDeviceName = preferences.getString(KEY_BT_DEVICE_NAME, "LEXON MINO L");
     currentBluetoothAutoReconnect = preferences.getBool(KEY_BT_AUTO_RECONNECT, false);
@@ -61,9 +69,11 @@ void saveSettings() {
     preferences.putInt(KEY_ROTATION, screenRotationSetting);
     preferences.putBool(KEY_BOOT_ANIM, playBootAnimation);
     preferences.putBool(KEY_AUTO_SLEEP, enableAutoSleep);
-    preferences.putBool(KEY_SHOW_TOTAL_TIME, showTotalTime);
+
     preferences.putInt(KEY_MIN_FIRST_SHOT, minFirstShotTimeMs);
     preferences.putInt(KEY_POST_BEEP_DELAY, postBeepDelayMs);
+    preferences.putInt(KEY_START_DELAY_MIN, startDelayMinMs);
+    preferences.putInt(KEY_START_DELAY_MAX, startDelayMaxMs);
 
     preferences.putString(KEY_BT_DEVICE_NAME, currentBluetoothDeviceName);
     preferences.putBool(KEY_BT_AUTO_RECONNECT, currentBluetoothAutoReconnect);

--- a/code/timer_modes.cpp
+++ b/code/timer_modes.cpp
@@ -27,19 +27,36 @@ void handleLiveFireReady() {
     }
     if (StickCP2.BtnA.wasClicked()) {
         resetActivityTimer();
-        reset_bt_beep_state(); 
-        is_listening_active = false; 
-        setState(LIVE_FIRE_GET_READY);
+        reset_bt_beep_state();
+        is_listening_active = false;
         StickCP2.Lcd.fillScreen(BLACK);
         StickCP2.Lcd.setTextDatum(MC_DATUM);
         StickCP2.Lcd.setTextFont(0);
         StickCP2.Lcd.setTextSize(3);
         StickCP2.Lcd.drawString("Ready...", StickCP2.Lcd.width()/2, StickCP2.Lcd.height()/2);
-        delay(1000); 
+        delay(1000);
+        randomSeed(micros());
+        unsigned long randomDelay = random(startDelayMinMs, startDelayMaxMs + 1);
+        liveFireDelayEndTime = millis() + randomDelay;
+        liveFireWaitingForDelay = true;
+        setState(LIVE_FIRE_GET_READY);
     }
 }
 
 void handleLiveFireGetReady() {
+    if (liveFireWaitingForDelay) {
+        if (StickCP2.BtnA.wasClicked()) {
+            liveFireWaitingForDelay = false;
+            setState(LIVE_FIRE_READY);
+            StickCP2.Lcd.fillScreen(BLACK);
+            playUnsuccessBeeps();
+            return;
+        }
+        if (millis() < liveFireDelayEndTime) {
+            return;
+        }
+        liveFireWaitingForDelay = false;
+    }
     resetActivityTimer();
     unsigned long beepInitiationTime = millis();
     playTone(currentBeepToneHz, currentBeepDuration); // Only plays on BT if connected, otherwise queues for buzzer
@@ -110,11 +127,12 @@ void handleLiveFireTiming() {
     }
 
     // Shot Detection Logic 
-    if (currentCyclePeakRMS > shotThresholdRms && 
-        currentTime - lastDetectionTime > SHOT_REFRACTORY_MS && 
-        shotCount < currentMaxShots && 
+    if (currentCyclePeakRMS > shotThresholdRms &&
+        currentTime - lastDetectionTime > SHOT_REFRACTORY_MS &&
+        shotCount < MAX_SHOTS_LIMIT &&
+        (currentMaxShots == 0 || shotCount < currentMaxShots) &&
         startTime > 0 &&
-        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs)) 
+        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs))
     {
         unsigned long shotTimeMillis = currentTime; 
         resetActivityTimer();
@@ -134,8 +152,8 @@ void handleLiveFireTiming() {
         displayTimingScreen(currentElapsedTime, shotCount, currentSplit); 
         lastDisplayUpdateTime = currentTime; 
 
-        if (shotCount >= currentMaxShots) {
-            is_listening_active = false; 
+        if (currentMaxShots > 0 && shotCount >= currentMaxShots) {
+            is_listening_active = false;
             setState(LIVE_FIRE_STOPPED);
             StickCP2.Lcd.fillScreen(BLACK);
             displayStoppedScreen();
@@ -370,9 +388,10 @@ void handleNoisyRangeTiming() {
     if (!checkingForRecoil &&
         currentCyclePeakRMS > shotThresholdRms &&
         currentTime - lastDetectionTime > SHOT_REFRACTORY_MS &&
-        shotCount < currentMaxShots &&
+        shotCount < MAX_SHOTS_LIMIT &&
+        (currentMaxShots == 0 || shotCount < currentMaxShots) &&
         startTime > 0 &&
-        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs)) 
+        (shotCount > 0 || (currentTime - startTime) >= minFirstShotTimeMs))
     {
         lastSoundPeakTime = currentTime;
         checkingForRecoil = true;
@@ -404,13 +423,13 @@ void handleNoisyRangeTiming() {
             lastSoundPeakTime = 0;
             micPeakRMS.resetPeak(); // Reset peak after successful shot registration
 
-            if (shotCount >= currentMaxShots) {
+            if (currentMaxShots > 0 && shotCount >= currentMaxShots) {
                 is_listening_active = false;
-                setState(LIVE_FIRE_STOPPED); 
+                setState(LIVE_FIRE_STOPPED);
                 StickCP2.Lcd.fillScreen(BLACK);
                 displayStoppedScreen();
                 if (shotCount > 0) playSuccessBeeps(); else playUnsuccessBeeps();
-                return; 
+                return;
             }
         }
         else if (currentTime - lastSoundPeakTime > RECOIL_DETECTION_WINDOW_MS) {


### PR DESCRIPTION
## Changes

- **Menu restructuring**: Reorganized settings menu hierarchy
  - Moved Live Fire settings to dedicated submenu (previously General)
  - Created new Device settings submenu with screen rotation, boot animation, auto sleep, device status, and file listing
  - Separated Beep settings into its own submenu
  - Updated menu navigation and state management accordingly

- **Shot limit enhancements**:
  - Changed max shots limit from 20 to 99
  - Added "Off" option for max shots (value 0 = unlimited shots)
  - Updated display to show "Shots: X" when unlimited, or "Shots: X/Y" when limited

- **Random start delay for Live Fire**:
  - Added `startDelayMinMs` and `startDelayMaxMs` configuration variables
  - Implemented random delay between min and max on Live Fire start
  - Added new editable settings for min/max start delay (0-10000ms)
  - Users can now abort the random delay by pressing button A

- **Removed features**:
  - Removed `showTotalTime` boolean setting (total time now always displayed)
  - Removed `KEY_SHOW_TOTAL_TIME` from NVS storage

- **Other improvements**:
  - Updated menu item navigation indices after restructuring
  - Added proper state and menu level tracking for all new settings
  - Enhanced display logic for new settings with millisecond units
  - Improved shot detection to properly handle unlimited shot mode