### PR TITLE
Web OTA firmware update via WiFi access point

### DIFF
--- a/code/code.ino
+++ b/code/code.ino
@@ -24,6 +24,7 @@
 #include "bluetooth_utils.h"
 #include "nvs_utils.h"
 #include "system_utils.h"
+#include "ota_utils.h"
 
 
 // --- Global Variable Definitions ---
@@ -260,11 +261,12 @@ void loop() {
         }
     }
 
-    if (enableAutoSleep && 
-        currentState != BOOT_SCREEN && 
-        currentState != BOOT_JPG_SEQUENCE && 
-        currentState != BLUETOOTH_SCANNING && 
-        !a2dp_source.is_connected() ) { 
+    if (enableAutoSleep &&
+        currentState != BOOT_SCREEN &&
+        currentState != BOOT_JPG_SEQUENCE &&
+        currentState != BLUETOOTH_SCANNING &&
+        currentState != OTA_UPDATE &&
+        !a2dp_source.is_connected() ) {
         if (currentTime - lastActivityTime > AUTO_SLEEP_TIMEOUT_MS) {
             StickCP2.Lcd.fillScreen(BLACK);
             StickCP2.Lcd.setTextDatum(MC_DATUM);
@@ -321,7 +323,8 @@ void loop() {
                      currentState != SETTINGS_MENU_BEEP && currentState != SETTINGS_MENU_BLUETOOTH &&
                      currentState != SETTINGS_MENU_DRYFIRE && currentState != SETTINGS_MENU_NOISY &&
                      currentState != SETTINGS_MENU_DEVICE &&
-                     currentState != BLUETOOTH_SCANNING && 
+                     currentState != OTA_UPDATE &&
+                     currentState != BLUETOOTH_SCANNING &&
                      currentState != DEVICE_STATUS && currentState != LIST_FILES && 
                      currentState != EDIT_SETTING && currentState != CALIBRATE_THRESHOLD && 
                      currentState != CALIBRATE_RECOIL &&
@@ -456,7 +459,8 @@ void loop() {
         case LIST_FILES:              handleListFilesInput(); break;
         case CALIBRATE_THRESHOLD:
         case CALIBRATE_RECOIL:        handleCalibrationInput(currentState); break;
-        default: break; 
+        case OTA_UPDATE:              handleOtaUpdateLoop(); break;
+        default: break;
     }
     vTaskDelay(pdMS_TO_TICKS(10)); 
 }

--- a/code/config.h
+++ b/code/config.h
@@ -91,7 +91,8 @@ enum TimerState {
     LIST_FILES,
     EDIT_SETTING,
     CALIBRATE_THRESHOLD,
-    CALIBRATE_RECOIL
+    CALIBRATE_RECOIL,
+    OTA_UPDATE
 };
 
 // --- Operating Modes ---

--- a/code/display_utils.cpp
+++ b/code/display_utils.cpp
@@ -100,7 +100,8 @@ void displayMenu(const char* title, const char* items[], int count, int selectio
                               strcmp(items[i], "Beep Settings") == 0 ||
                               strcmp(items[i], "Bluetooth Settings") == 0 ||
                               strcmp(items[i], "Tone Sweep") == 0 ||
-                              strcmp(items[i], "Save & Exit") == 0);
+                              strcmp(items[i], "Save & Exit") == 0 ||
+                              strcmp(items[i], "Update Firmware") == 0);
 
         bool isParTimeSetting = (settingsMenuLevel == 2 && strncmp(items[i], "Par Time", 8) == 0);
         bool isBluetoothConnectItem = (settingsMenuLevel == 5 && strcmp(items[i], "Connect") == 0 );

--- a/code/input_handler.cpp
+++ b/code/input_handler.cpp
@@ -5,7 +5,8 @@
 #include "nvs_utils.h"
 #include "system_utils.h"
 #include "audio_utils.h"     // For reset_bt_beep_state
-#include "bluetooth_utils.h" 
+#include "bluetooth_utils.h"
+#include "ota_utils.h"
 #include <LittleFS.h>
 
 
@@ -63,7 +64,7 @@ void handleSettingsInput() {
     static const char* liveFireItems[] = {"Max Shots", "Shot Threshold", "Min 1st Shot", "Start Delay Min", "Start Delay Max", "Calibrate Thresh.", "Back"};
     static const char* beepItems[] = {"Beep Duration", "Beep Tone", "Post Beep Delay", "Tone Sweep", "Back"};
     static const char* noisyItems[] = {"Recoil Threshold", "Calibrate Recoil", "Back"};
-    static const char* deviceItems[] = {"Screen Rotation", "Boot Animation", "Auto Sleep", "Device Status", "List Files", "Back"};
+    static const char* deviceItems[] = {"Screen Rotation", "Boot Animation", "Auto Sleep", "Device Status", "List Files", "Update Firmware", "Back"};
 
     const int maxDryFireItems = 1 + MAX_PAR_BEEPS + 1;
     static const char* dryFireItemsBuffer[maxDryFireItems];
@@ -355,6 +356,8 @@ void handleSettingsInput() {
                 setState(DEVICE_STATUS); needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
             } else if (strcmp(editingSettingName, "List Files") == 0) {
                 setState(LIST_FILES); fileListScrollOffset = 0; needsActionRedraw = false; StickCP2.Lcd.fillScreen(BLACK);
+            } else if (strcmp(editingSettingName, "Update Firmware") == 0) {
+                setState(OTA_UPDATE); startOtaUpdate(); needsActionRedraw = false;
             } else if (strcmp(editingSettingName, "Back") == 0) {
                 settingsMenuLevel = 0; currentMenuSelection = 5; menuScrollOffset = 0;
             }

--- a/code/ota_utils.cpp
+++ b/code/ota_utils.cpp
@@ -1,0 +1,206 @@
+#include "ota_utils.h"
+#include "globals.h"
+#include "config.h"
+#include "system_utils.h"
+#include "audio_utils.h"
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Update.h>
+
+static WebServer* server = nullptr;
+static bool otaInProgress = false;
+static bool otaSuccess = false;
+
+static const char* AP_SSID = "ShotTimer-Update";
+static const char* AP_PASS = "update1234";
+
+static const char OTA_HTML[] PROGMEM = R"rawliteral(
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shot Timer OTA Update</title>
+<style>
+body { font-family: Arial, sans-serif; text-align: center; padding: 20px; background: #1a1a1a; color: #fff; }
+h1 { color: #4CAF50; }
+.upload-form { margin: 30px auto; padding: 20px; max-width: 400px; background: #2d2d2d; border-radius: 10px; }
+input[type="file"] { margin: 15px 0; color: #fff; }
+input[type="submit"] { background: #4CAF50; color: white; padding: 12px 30px; border: none; border-radius: 5px; font-size: 16px; cursor: pointer; }
+input[type="submit"]:hover { background: #45a049; }
+.progress { display: none; margin: 20px auto; width: 80%; background: #444; border-radius: 5px; }
+.progress-bar { width: 0%; height: 30px; background: #4CAF50; border-radius: 5px; text-align: center; line-height: 30px; color: white; transition: width 0.3s; }
+.warning { color: #ff9800; font-size: 14px; margin-top: 15px; }
+</style>
+</head>
+<body>
+<h1>Shot Timer</h1>
+<h2>Firmware Update</h2>
+<div class="upload-form">
+<form method="POST" action="/update" enctype="multipart/form-data" id="uploadForm">
+<input type="file" name="update" accept=".bin" required><br>
+<input type="submit" value="Upload Firmware">
+</form>
+<div class="progress" id="progress">
+<div class="progress-bar" id="progressBar">0%</div>
+</div>
+<p class="warning">Do not power off during update!</p>
+</div>
+<script>
+document.getElementById('uploadForm').addEventListener('submit', function() {
+    document.getElementById('progress').style.display = 'block';
+    var bar = document.getElementById('progressBar');
+    var pct = 0;
+    var interval = setInterval(function() {
+        if (pct < 90) { pct += 5; bar.style.width = pct + '%'; bar.textContent = pct + '%'; }
+    }, 500);
+});
+</script>
+</body>
+</html>
+)rawliteral";
+
+static void displayOtaScreen() {
+    StickCP2.Lcd.fillScreen(BLACK);
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    StickCP2.Lcd.setTextDatum(TC_DATUM);
+    StickCP2.Lcd.setTextFont(0);
+    StickCP2.Lcd.setTextSize(2);
+    StickCP2.Lcd.drawString("OTA Update", StickCP2.Lcd.width() / 2, 5);
+
+    StickCP2.Lcd.setTextSize(1);
+    StickCP2.Lcd.setTextDatum(TL_DATUM);
+    int y = 30;
+    int lineH = 14;
+
+    StickCP2.Lcd.drawString("WiFi Network:", 10, y); y += lineH;
+    StickCP2.Lcd.setTextColor(GREEN, BLACK);
+    StickCP2.Lcd.drawString(AP_SSID, 10, y); y += lineH + 2;
+
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    StickCP2.Lcd.drawString("Password:", 10, y); y += lineH;
+    StickCP2.Lcd.setTextColor(GREEN, BLACK);
+    StickCP2.Lcd.drawString(AP_PASS, 10, y); y += lineH + 2;
+
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    StickCP2.Lcd.drawString("Open in browser:", 10, y); y += lineH;
+    StickCP2.Lcd.setTextColor(GREEN, BLACK);
+    StickCP2.Lcd.drawString("http://192.168.4.1", 10, y);
+
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    StickCP2.Lcd.setTextDatum(BC_DATUM);
+    StickCP2.Lcd.drawString("Hold Front to Cancel", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() - 5);
+}
+
+static void displayOtaUploading() {
+    StickCP2.Lcd.fillScreen(BLACK);
+    StickCP2.Lcd.setTextColor(WHITE, BLACK);
+    StickCP2.Lcd.setTextDatum(MC_DATUM);
+    StickCP2.Lcd.setTextFont(0);
+    StickCP2.Lcd.setTextSize(3);
+    StickCP2.Lcd.drawString("Uploading...", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2);
+}
+
+static void handleRoot() {
+    server->send(200, "text/html", OTA_HTML);
+}
+
+static void handleUpdateComplete() {
+    if (otaSuccess) {
+        server->send(200, "text/html", "<html><body style='background:#1a1a1a;color:#4CAF50;text-align:center;padding:50px;font-family:Arial'><h1>Update Successful!</h1><p>Rebooting...</p></body></html>");
+        StickCP2.Lcd.fillScreen(BLACK);
+        StickCP2.Lcd.setTextColor(GREEN, BLACK);
+        StickCP2.Lcd.setTextDatum(MC_DATUM);
+        StickCP2.Lcd.setTextFont(0);
+        StickCP2.Lcd.setTextSize(2);
+        StickCP2.Lcd.drawString("Update OK!", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2 - 10);
+        StickCP2.Lcd.setTextSize(1);
+        StickCP2.Lcd.drawString("Rebooting...", StickCP2.Lcd.width() / 2, StickCP2.Lcd.height() / 2 + 15);
+        delay(2000);
+        ESP.restart();
+    } else {
+        server->send(500, "text/html", "<html><body style='background:#1a1a1a;color:#f44336;text-align:center;padding:50px;font-family:Arial'><h1>Update Failed!</h1><p><a href='/' style='color:#4CAF50'>Try Again</a></p></body></html>");
+        // Redraw the OTA screen so user can retry
+        displayOtaScreen();
+    }
+}
+
+static void handleUpdateUpload() {
+    HTTPUpload& upload = server->upload();
+
+    if (upload.status == UPLOAD_FILE_START) {
+        otaInProgress = true;
+        displayOtaUploading();
+
+        if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
+            otaInProgress = false;
+            otaSuccess = false;
+        }
+    } else if (upload.status == UPLOAD_FILE_WRITE) {
+        if (Update.write(upload.buf, upload.currentSize) != upload.currentSize) {
+            otaSuccess = false;
+        }
+    } else if (upload.status == UPLOAD_FILE_END) {
+        if (Update.end(true)) {
+            otaSuccess = true;
+        } else {
+            otaSuccess = false;
+        }
+        otaInProgress = false;
+    } else if (upload.status == UPLOAD_FILE_ABORTED) {
+        Update.abort();
+        otaInProgress = false;
+        otaSuccess = false;
+    }
+}
+
+void startOtaUpdate() {
+    // Disconnect Bluetooth if connected to free up the radio
+    if (a2dp_source.is_connected()) {
+        a2dp_source.disconnect();
+    }
+
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(AP_SSID, AP_PASS);
+
+    server = new WebServer(80);
+    server->on("/", HTTP_GET, handleRoot);
+    server->on("/update", HTTP_POST, handleUpdateComplete, handleUpdateUpload);
+    server->begin();
+
+    otaInProgress = false;
+    otaSuccess = false;
+
+    displayOtaScreen();
+}
+
+void handleOtaUpdateLoop() {
+    if (server != nullptr) {
+        server->handleClient();
+    }
+
+    // Allow cancel only when not mid-upload
+    if (!otaInProgress && StickCP2.BtnA.pressedFor(LONG_PRESS_DURATION_MS)) {
+        stopOtaUpdate();
+        settingsMenuLevel = 6;
+        setState(SETTINGS_MENU_DEVICE);
+        currentMenuSelection = 5; // "Update Firmware" index in deviceItems
+        menuScrollOffset = 0;
+        StickCP2.Lcd.fillScreen(BLACK);
+        playUnsuccessBeeps();
+    }
+}
+
+void stopOtaUpdate() {
+    if (otaInProgress) {
+        Update.abort();
+    }
+    if (server != nullptr) {
+        server->stop();
+        delete server;
+        server = nullptr;
+    }
+    WiFi.softAPdisconnect(true);
+    WiFi.mode(WIFI_OFF);
+    otaInProgress = false;
+    otaSuccess = false;
+}

--- a/code/ota_utils.h
+++ b/code/ota_utils.h
@@ -1,0 +1,11 @@
+#ifndef OTA_UTILS_H
+#define OTA_UTILS_H
+
+#include <M5StickCPlus2.h>
+#include "config.h"
+
+void startOtaUpdate();
+void handleOtaUpdateLoop();
+void stopOtaUpdate();
+
+#endif // OTA_UTILS_H


### PR DESCRIPTION
## Summary
- **Web OTA firmware update** via WiFi AP (ShotTimer-Update / update1234). Displays SSID, password, and IP on screen. WiFi only active on the OTA screen, fully powered off on exit
- Bluetooth disconnected before starting WiFi since they share the ESP32 radio
- Auto-sleep disabled during OTA to prevent sleeping mid-upload
- New "Update Firmware" option added to Device settings submenu

## Test plan
- [ ] Open Update Firmware from Device menu, confirm SSID/password/IP displayed
- [ ] Connect to WiFi AP from phone/laptop, open 192.168.4.1 in browser
- [ ] Upload a .bin file, confirm "Uploading..." shown on device and successful reboot
- [ ] Cancel OTA with long press, confirm WiFi is turned off and returns to Device menu
- [ ] Verify auto-sleep does not trigger while on OTA screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)